### PR TITLE
gitignoreを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+
+#Ignore thumbnails created by Windows
+Thumbs.db
+#Ignore files built by Visual Studio
+*.obj
+*.exe
+*.pdb
+*.user
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Bb]in
+[Dd]ebug*/
+*.lib
+*.sbr
+obj/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*
+.vs/
+.idea/
+#Nuget packages folder
+packages/


### PR DESCRIPTION
## 詳細
自宅サーバ上にリモートリポジトリを置いていたが、今後のGithub関連ツールの活用に向けて、Github上に開発リモートリポジトリを移動する

## 関連Issue
#94 

## 影響範囲
なし

## 確認項目

- [x] ビルド成功し、従来同様に動作すること
- [x] 不要なファイルをプッシュしないこと